### PR TITLE
Restrict lodash.js to version 3.10.1 as version 4.0.0+ renames variou…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -55,7 +55,8 @@
     "angular-translate-loader-partial": "~2.7.2",
     "angulartics": "~0.19.0",
     "waypoints": "~3.1.1",
-    "angular-slick-carousel": "~3.1.4"
+    "angular-slick-carousel": "~3.1.4",
+    "lodash": "3.10.1"
   },
   "resolutions": {
     "moment": "master",


### PR DESCRIPTION
…s underscore.js methods and breaks everything
